### PR TITLE
chore(actions): Replace deprecated ::set-output syntax on action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,9 +71,9 @@ runs:
 
     - run: |
         if [ "$ASSET_NAME" == "" ]; then
-          echo ::set-output name=name::${{ github.event.repository.name }}-${{ inputs.release-version }}-all.zip
+          echo "name=${{ github.event.repository.name }}-${{ inputs.release-version }}-all.zip" >> $GITHUB_OUTPUT
         else
-          echo ::set-output name=name::"$ASSET_NAME"
+          echo "name=$(echo $ASSET_NAME)" >> $GITHUB_OUTPUT          
         fi
       shell: bash
       env:


### PR DESCRIPTION
On may, ::set-output name={name}::{value} will be EOL, we replaced it from echo "{name}={value}" >> $GITHUB_OUTPUT synthax