### PR TITLE
tr(gh-action): replace deprecated github actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,18 +50,6 @@ runs:
       env:
         REPO: ${{ github.repository }}
 
-    - uses: actions/create-release@latest
-      id: create_release
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      with:
-        tag_name: ${{ inputs.release-version }}
-        release_name: Release ${{ inputs.release-version }}
-        body: |
-          ${{ steps.Changelog.outputs.changelog }}
-        draft: false
-        prerelease: false
-
     - run: ${{ inputs.build-and-release-command-line }}
       shell: bash
       env:
@@ -73,19 +61,17 @@ runs:
         if [ "$ASSET_NAME" == "" ]; then
           echo "name=${{ github.event.repository.name }}-${{ inputs.release-version }}-all.zip" >> $GITHUB_OUTPUT
         else
-          echo "name=$(echo $ASSET_NAME)" >> $GITHUB_OUTPUT          
+          echo "name=$(echo $ASSET_NAME)" >> $GITHUB_OUTPUT
         fi
       shell: bash
       env:
         ASSET_NAME: ${{ inputs.asset-name }}
       id: evaluate_asset_name
 
-    - uses: actions/upload-release-asset@v1
-      id: upload-release-asset 
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+    - uses: ncipollo/release-action@v1
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: ${{ inputs.asset-path }}/${{ steps.evaluate_asset_name.outputs.name }}
-        asset_name: ${{ steps.evaluate_asset_name.outputs.name }}
-        asset_content_type: application/zip
+        tag: ${{ inputs.release-version }}
+        name: Release ${{ inputs.release-version }}
+        body: |
+          ${{ steps.Changelog.outputs.changelog }}
+        artifacts: ${{ inputs.asset-path }}/${{ steps.evaluate_asset_name.outputs.name }}


### PR DESCRIPTION
actions/create-release & actions/upload-release-asset are not maintained anymore and are running on deprecated Node12 (see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

[JIRA CI-775](https://bonitasoft.atlassian.net/browse/CI-775)